### PR TITLE
Fix update equations to always use variance

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -40,7 +40,7 @@ def random_baseline():
     reagent_file_list = ["data/aminobenzoic_100.smi", "data/primary_amines_100.smi", "data/carboxylic_acids_100.smi"]
     quinazoline_smarts = "N[c:4][c:3]C(O)=O.[#6:1][NH2].[#6:2]C(=O)[OH]>>[C:2]c1n[c:4][c:3]c(=O)n1[C:1]"
     rxn = AllChem.ReactionFromSmarts(quinazoline_smarts)
-    reagent_df_list = read_reagents(reagent_file_list, num_reagents_to_read, minimum_uncertainty=.1, known_std=2.0)
+    reagent_df_list = read_reagents(reagent_file_list, num_reagents_to_read, minimum_uncertainty=.1, known_std=1.0)
 
     mol_lol = [x.mol for x in reagent_df_list]
     len_list = [len(x) for x in reagent_df_list]

--- a/baseline.py
+++ b/baseline.py
@@ -40,7 +40,7 @@ def random_baseline():
     reagent_file_list = ["data/aminobenzoic_100.smi", "data/primary_amines_100.smi", "data/carboxylic_acids_100.smi"]
     quinazoline_smarts = "N[c:4][c:3]C(O)=O.[#6:1][NH2].[#6:2]C(=O)[OH]>>[C:2]c1n[c:4][c:3]c(=O)n1[C:1]"
     rxn = AllChem.ReactionFromSmarts(quinazoline_smarts)
-    reagent_df_list = read_reagents(reagent_file_list, num_reagents_to_read)
+    reagent_df_list = read_reagents(reagent_file_list, num_reagents_to_read, minimum_uncertainty=.1, prior_std=2.0)
 
     mol_lol = [x.mol for x in reagent_df_list]
     len_list = [len(x) for x in reagent_df_list]

--- a/baseline.py
+++ b/baseline.py
@@ -40,7 +40,7 @@ def random_baseline():
     reagent_file_list = ["data/aminobenzoic_100.smi", "data/primary_amines_100.smi", "data/carboxylic_acids_100.smi"]
     quinazoline_smarts = "N[c:4][c:3]C(O)=O.[#6:1][NH2].[#6:2]C(=O)[OH]>>[C:2]c1n[c:4][c:3]c(=O)n1[C:1]"
     rxn = AllChem.ReactionFromSmarts(quinazoline_smarts)
-    reagent_df_list = read_reagents(reagent_file_list, num_reagents_to_read, minimum_uncertainty=.1, prior_std=2.0)
+    reagent_df_list = read_reagents(reagent_file_list, num_reagents_to_read, minimum_uncertainty=.1, known_std=2.0)
 
     mol_lol = [x.mol for x in reagent_df_list]
     len_list = [len(x) for x in reagent_df_list]

--- a/thompson_sampling.py
+++ b/thompson_sampling.py
@@ -14,14 +14,14 @@ from ts_utils import read_reagents
 
 
 class ThompsonSampler:
-    def __init__(self, prior_std: float, mode="maximize", minimum_uncertainty: float = .1):
+    def __init__(self, known_std: float, mode="maximize", minimum_uncertainty: float = .1):
         """
         Basic init
         :param mode: maximize or minimize
         :param minimum_uncertainty: Minimum uncertainty about the mean for the prior. We don't want to start with too
         little uncertainty about the mean if we (randomly) get initial samples which are very close together. Can set
         this higher for more exploration / diversity, lower for more exploitation.
-        :param prior_std: This is the "known" standard deviation for the distribution of which we are trying to estimate
+        :param known_std: This is the "known" standard deviation for the distribution of which we are trying to estimate
         the mean. Should be proportional to the range of possible values the scoring function can produce.
         """
         # A list of lists of Reagents. Each component in the reaction will have one list of Reagents in this list
@@ -29,7 +29,7 @@ class ThompsonSampler:
         self.reaction = None
         self.evaluator = None
         self.minimum_uncertainty = minimum_uncertainty
-        self.prior_std: float = prior_std
+        self.known_std: float = known_std
         if mode == "maximize":
             self.pick_function = np.argmax
         elif mode == "minimize":
@@ -45,7 +45,7 @@ class ThompsonSampler:
         :return: None
         """
         self.reagent_lists = read_reagents(reagent_file_list, num_to_select,
-                                           minimum_uncertainty=self.minimum_uncertainty, prior_std=self.prior_std)
+                                           minimum_uncertainty=self.minimum_uncertainty, known_std=self.known_std)
         num_prods = math.prod([len(x) for x in self.reagent_lists])
         print(f"{num_prods:.2e} possible products")
 
@@ -154,7 +154,7 @@ class ThompsonSampler:
 def main():
     num_iterations = 1000
     reagent_file_list = ["data/aminobenzoic_ok.smi", "data/primary_amines_ok.smi", "data/carboxylic_acids_ok.smi"]
-    ts = ThompsonSampler(minimum_uncertainty=1.0, prior_std=2.0)
+    ts = ThompsonSampler(minimum_uncertainty=1.0, known_std=2.0)
     fp_evaluator = FPEvaluator("COC(=O)[C@@H](CC(=O)O)n1c(C[C@H](O)C(=O)OC)nc2c(OC)cccc2c1=O")
     ts.set_evaluator(fp_evaluator)
     # rocs_evaluator = ROCSEvaluator("data/2chw_lig.sdf")

--- a/thompson_sampling.py
+++ b/thompson_sampling.py
@@ -154,7 +154,7 @@ class ThompsonSampler:
 def main():
     num_iterations = 1000
     reagent_file_list = ["data/aminobenzoic_ok.smi", "data/primary_amines_ok.smi", "data/carboxylic_acids_ok.smi"]
-    ts = ThompsonSampler(minimum_uncertainty=1.0, known_std=2.0)
+    ts = ThompsonSampler(minimum_uncertainty=.1, known_std=1.0)
     fp_evaluator = FPEvaluator("COC(=O)[C@@H](CC(=O)O)n1c(C[C@H](O)C(=O)OC)nc2c(OC)cccc2c1=O")
     ts.set_evaluator(fp_evaluator)
     # rocs_evaluator = ROCSEvaluator("data/2chw_lig.sdf")

--- a/thompson_sampling.py
+++ b/thompson_sampling.py
@@ -143,7 +143,7 @@ class ThompsonSampler:
             pick = [self.pick_function(x) for x in choice_list]
             smiles, score = self.evaluate(pick)
             out_list.append([score, smiles])
-            if i % 10 == 0:
+            if i % 100 == 0:
                 sorted_outlist = sorted(out_list, reverse=True)
                 top_score = sorted_outlist[0][0]
                 top_smiles = sorted_outlist[0][1]

--- a/ts_utils.py
+++ b/ts_utils.py
@@ -3,13 +3,15 @@ from typing import List, Optional
 from reagent import Reagent
 
 
-def create_reagents(filename: str, minimum_uncertainty: float, num_to_select: Optional[int] = None) -> List[Reagent]:
+def create_reagents(filename: str, minimum_uncertainty: float, prior_std: float, num_to_select: Optional[int] = None) -> List[Reagent]:
     """
     Creates a list of Reagents from a file
     :param filename: a smiles file containing the reagents
     :param minimum_uncertainty: Minimum uncertainty about the mean for the prior. We don't want to start with too little
     uncertainty about the mean if we (randomly) get initial samples which are very close together. Can set this
     higher for more exploration / diversity, lower for more exploitation.
+    :param prior_std: This is the "known" standard deviation for the distribution of which we are trying to estimate the
+    mean. Should be proportional to the range of possible values the scoring function can produce.
     :param num_to_select: For dev purposes; the number of molecules to return
     :return: List of Reagents
     """
@@ -17,14 +19,14 @@ def create_reagents(filename: str, minimum_uncertainty: float, num_to_select: Op
     with open(filename, 'r') as f:
         for line in f.readlines():
             smiles, reagent_name = line.split()
-            reagent = Reagent(reagent_name=reagent_name, smiles=smiles, minimum_uncertainty=minimum_uncertainty)
+            reagent = Reagent(reagent_name=reagent_name, smiles=smiles, minimum_uncertainty=minimum_uncertainty, known_std=prior_std)
             reagent_list.append(reagent)
     if num_to_select is not None and len(reagent_list) > num_to_select:
         reagent_list = reagent_list[:num_to_select]
     return reagent_list
 
 
-def read_reagents(reagent_file_list, num_to_select: Optional[int], minimum_uncertainty: float):
+def read_reagents(reagent_file_list, num_to_select: Optional[int], minimum_uncertainty: float, prior_std: float):
     """
     Read the reagents SMILES files
     :param reagent_file_list: a list of filenames containing reagents for the reaction. Each file list contains smiles
@@ -33,10 +35,12 @@ def read_reagents(reagent_file_list, num_to_select: Optional[int], minimum_uncer
     :param minimum_uncertainty: Minimum uncertainty about the mean for the prior. We don't want to start with too little
     uncertainty about the mean if we (randomly) get initial samples which are very close together. Can set this
     higher for more exploration / diversity, lower for more exploitation.
+    :param prior_std: This is the "known" standard deviation for the distribution of which we are trying to estimate the
+    mean. Should be proportional to the range of possible values the scoring function can produce.
     """
     reagents = []
     for reagent_filename in reagent_file_list:
         reagent_list = create_reagents(filename=reagent_filename, num_to_select=num_to_select,
-                                       minimum_uncertainty=minimum_uncertainty)
+                                       minimum_uncertainty=minimum_uncertainty, prior_std=prior_std)
         reagents.append(reagent_list)
     return reagents

--- a/ts_utils.py
+++ b/ts_utils.py
@@ -3,14 +3,14 @@ from typing import List, Optional
 from reagent import Reagent
 
 
-def create_reagents(filename: str, minimum_uncertainty: float, prior_std: float, num_to_select: Optional[int] = None) -> List[Reagent]:
+def create_reagents(filename: str, minimum_uncertainty: float, known_std: float, num_to_select: Optional[int] = None) -> List[Reagent]:
     """
     Creates a list of Reagents from a file
     :param filename: a smiles file containing the reagents
     :param minimum_uncertainty: Minimum uncertainty about the mean for the prior. We don't want to start with too little
     uncertainty about the mean if we (randomly) get initial samples which are very close together. Can set this
     higher for more exploration / diversity, lower for more exploitation.
-    :param prior_std: This is the "known" standard deviation for the distribution of which we are trying to estimate the
+    :param known_std: This is the "known" standard deviation for the distribution of which we are trying to estimate the
     mean. Should be proportional to the range of possible values the scoring function can produce.
     :param num_to_select: For dev purposes; the number of molecules to return
     :return: List of Reagents
@@ -19,14 +19,14 @@ def create_reagents(filename: str, minimum_uncertainty: float, prior_std: float,
     with open(filename, 'r') as f:
         for line in f.readlines():
             smiles, reagent_name = line.split()
-            reagent = Reagent(reagent_name=reagent_name, smiles=smiles, minimum_uncertainty=minimum_uncertainty, known_std=prior_std)
+            reagent = Reagent(reagent_name=reagent_name, smiles=smiles, minimum_uncertainty=minimum_uncertainty, known_std=known_std)
             reagent_list.append(reagent)
     if num_to_select is not None and len(reagent_list) > num_to_select:
         reagent_list = reagent_list[:num_to_select]
     return reagent_list
 
 
-def read_reagents(reagent_file_list, num_to_select: Optional[int], minimum_uncertainty: float, prior_std: float):
+def read_reagents(reagent_file_list, num_to_select: Optional[int], minimum_uncertainty: float, known_std: float):
     """
     Read the reagents SMILES files
     :param reagent_file_list: a list of filenames containing reagents for the reaction. Each file list contains smiles
@@ -35,12 +35,12 @@ def read_reagents(reagent_file_list, num_to_select: Optional[int], minimum_uncer
     :param minimum_uncertainty: Minimum uncertainty about the mean for the prior. We don't want to start with too little
     uncertainty about the mean if we (randomly) get initial samples which are very close together. Can set this
     higher for more exploration / diversity, lower for more exploitation.
-    :param prior_std: This is the "known" standard deviation for the distribution of which we are trying to estimate the
+    :param known_std: This is the "known" standard deviation for the distribution of which we are trying to estimate the
     mean. Should be proportional to the range of possible values the scoring function can produce.
     """
     reagents = []
     for reagent_filename in reagent_file_list:
         reagent_list = create_reagents(filename=reagent_filename, num_to_select=num_to_select,
-                                       minimum_uncertainty=minimum_uncertainty, prior_std=prior_std)
+                                       minimum_uncertainty=minimum_uncertainty, known_std=known_std)
         reagents.append(reagent_list)
     return reagents


### PR DESCRIPTION
- update the equations to always use variance
- change the name of prior_std to known_std (I thought the name prior_std was confusing since it is not the std of the prior)
- Made know_std a settable attribute (since this should probably change depending on the scale of the scoring function being used) 
- 